### PR TITLE
Fixes  #48 by having can_parse_alternatives actually check for only parsing of alternatives.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/src/chit/details/alternatives/mod.rs
+++ b/src/chit/details/alternatives/mod.rs
@@ -90,9 +90,12 @@ pub fn get_alternatives() -> Result<Alternatives, RetrieveAlternativesError> {
 mod tests {
     use super::*;
 
+    const ALTERNATIVES_JSON: &str = include_str!("../../../../alternatives.json");
+    /// Tests if the alternatives.json file in the root of this crate can be parsed.
     #[test]
     fn can_parse_alternatives() {
-        let alternatives = get_alternatives().expect("Alternative retrieval failed");
+        let alternatives: Alternatives = serde_json::from_str(&ALTERNATIVES_JSON)
+            .expect("Alternative parsing failed");
         assert_ne!(alternatives.sets.len(), 0)
     }
 }

--- a/src/chit/details/mod.rs
+++ b/src/chit/details/mod.rs
@@ -72,7 +72,7 @@ pub fn print_details(crate_name: String) {
                     ));
                 }
 
-                // IDEA: Clean this up by making it less imparative and into another file
+                // IDEA: Clean this up by making it less imperative and into another file
                 let mut found_alternative = false;
                 let alternatives = alternatives::get_alternatives();
 


### PR DESCRIPTION
**Description:**

Fixes #48 by having `can_parse_alternatives` actually check for the only parsing of `alternatives.json` file at the root of the repository, no network access needed.

**Related Issues: (optional)**

#48 
